### PR TITLE
Fix pk pkcs11 memleak

### DIFF
--- a/Middleware/Application-Protocols/network_transport/using_mbedtls_pkcs11/mbedtls_pk_pkcs11.c
+++ b/Middleware/Application-Protocols/network_transport/using_mbedtls_pkcs11/mbedtls_pk_pkcs11.c
@@ -387,56 +387,6 @@ CK_RV xPKCS11_initMbedtlsPkContext( mbedtls_pk_context * pxMbedtlsPkCtx,
 
 /*-----------------------------------------------------------*/
 
-int lPKCS11PkMbedtlsCloseSessionAndFree( mbedtls_pk_context * pxMbedtlsPkCtx )
-{
-    CK_RV xResult = CKR_OK;
-    P11PkCtx_t * pxP11Ctx = NULL;
-    CK_FUNCTION_LIST_PTR pxFunctionList = NULL;
-
-    configASSERT( pxMbedtlsPkCtx );
-
-    if( pxMbedtlsPkCtx )
-    {
-        if( pxMbedtlsPkCtx->pk_info->type == MBEDTLS_PK_ECKEY )
-        {
-            pxP11Ctx = &( ( ( P11EcDsaCtx_t * ) ( pxMbedtlsPkCtx->pk_ctx ) )->xP11PkCtx );
-        }
-        else if( pxMbedtlsPkCtx->pk_info->type == MBEDTLS_PK_RSA )
-        {
-            pxP11Ctx = &( ( ( P11RsaCtx_t * ) ( pxMbedtlsPkCtx->pk_ctx ) )->xP11PkCtx );
-        }
-        else
-        {
-            pxP11Ctx = NULL;
-            xResult = CKR_FUNCTION_FAILED;
-        }
-    }
-    else
-    {
-        xResult = CKR_FUNCTION_FAILED;
-    }
-
-    if( xResult == CKR_OK )
-    {
-        xResult = C_GetFunctionList( &pxFunctionList );
-    }
-
-    if( xResult == CKR_OK )
-    {
-        configASSERT( pxFunctionList );
-        xResult = pxFunctionList->C_CloseSession( pxP11Ctx->xSessionHandle );
-    }
-
-    if( xResult == CKR_OK )
-    {
-        pxP11Ctx->xSessionHandle = CK_INVALID_HANDLE;
-    }
-
-    return( xResult == CKR_OK ? 0 : -1 );
-}
-
-/*-----------------------------------------------------------*/
-
 int lPKCS11RandomCallback( void * pvCtx,
                            unsigned char * pucOutput,
                            size_t uxLen )

--- a/Middleware/Application-Protocols/network_transport/using_mbedtls_pkcs11/mbedtls_pk_pkcs11.h
+++ b/Middleware/Application-Protocols/network_transport/using_mbedtls_pkcs11/mbedtls_pk_pkcs11.h
@@ -47,15 +47,6 @@ CK_RV xPKCS11_initMbedtlsPkContext( mbedtls_pk_context * pxMbedtlsPkCtx,
                                     CK_OBJECT_HANDLE xPkHandle );
 
 /**
- * @brief Close the PKCS11 session and free the relevant pk context.
- *
- * @param pxMbedtlsPkCtx Pointer to the mbedtls_pk_context to free
- * @return 0 on success
- * @return A negative number on failure
- */
-int lPKCS11PkMbedtlsCloseSessionAndFree( mbedtls_pk_context * pxMbedtlsPkCtx );
-
-/**
  * @brief Callback to generate random data with the PKCS11 module.
  *
  * @param[in] pvCtx void pointer to the

--- a/Middleware/Application-Protocols/network_transport/using_mbedtls_pkcs11/transport_mbedtls_pkcs11.c
+++ b/Middleware/Application-Protocols/network_transport/using_mbedtls_pkcs11/transport_mbedtls_pkcs11.c
@@ -242,8 +242,7 @@ static void sslContextFree( SSLContext_t * pSslContext )
     mbedtls_x509_crt_free( &( pSslContext->clientCert ) );
     mbedtls_ssl_config_free( &( pSslContext->config ) );
 
-
-    ( void ) lPKCS11PkMbedtlsCloseSessionAndFree( &( pSslContext->privKey ) );
+    mbedtls_pk_free( &( pSslContext->privKey ) );
 
     pSslContext->pxP11FunctionList->C_CloseSession( pSslContext->xP11Session );
 }
@@ -571,7 +570,10 @@ static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
     }
 
     /* Free memory. */
-    vPortFree( xTemplate.pValue );
+    if( xTemplate.pValue != NULL )
+    {
+        vPortFree( xTemplate.pValue );
+    }
 
     return xResult;
 }
@@ -657,7 +659,10 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
     }
 
     /* Free memory. */
-    vPortFree( pxSlotIds );
+    if( pxSlotIds!= NULL )
+    {
+        vPortFree( pxSlotIds );
+    }
 
     return xResult;
 }


### PR DESCRIPTION
Remove unused iot_crypto.c file.
Fix memory leak in mbedtls_pkcs11 transport implementation